### PR TITLE
Implementing standard traits for SquirrelRng

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
-use rand::RngCore;
+use rand::{RngCore, SeedableRng};
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct SquirrelRng {
     position: u32,
     seed: u32,
@@ -14,10 +15,7 @@ impl SquirrelRng {
     }
 
     pub fn with_seed(seed: u32) -> Self {
-        Self {
-            position: 0,
-            seed,
-        }
+        Self { position: 0, seed }
     }
 }
 
@@ -51,6 +49,8 @@ impl RngCore for SquirrelRng {
         Ok(())
     }
 }
+
+
 
 pub fn squirrel3(position: u32, seed: u32) -> u32 {
     const BIT_NOISE1: u32 = 0x68E31DA4;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ impl RngCore for SquirrelRng {
     #[inline]
     fn next_u32(&mut self) -> u32 {
         let result = squirrel3(self.position, self.seed);
-        self.position += 1;
+        self.position = self.position.wrapping_add(1);
         result
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,13 @@ impl RngCore for SquirrelRng {
     }
 }
 
+impl SeedableRng for SquirrelRng {
+    type Seed = [u8; 4];
 
+    fn from_seed(seed: Self::Seed) -> Self {
+        Self::with_seed(u32::from_le_bytes(seed))
+    }
+}
 
 pub fn squirrel3(position: u32, seed: u32) -> u32 {
     const BIT_NOISE1: u32 = 0x68E31DA4;


### PR DESCRIPTION
Hello,

I really like this crate, and I've been using it myself, but I had some issues and thought it would be worthwhile to code up some improvements.

Changes:

+ I derived some traits like `Copy` and `Debug`, which aren't hugely useful here on their own, but allow other types containing a `SquirrelRng` to derive those traits as well. I can't see any reason why these shouldn't be implemented.
+ I implemented the `SeedableRng` trait from `rand`, simply using the seeding mechanism that's already in place.
+ I changed the `position` field to advance by a `wrapping_add` instead of `+=`. I don't think periodicity is a logic error worthy of causing debug builds to panic, so much as it is just a property of PRNGs with small amounts of state.

I haven't touched Cargo.toml, even though I think this accepting this PR would require a version update. This is my first time contributing code to an open-source project, so I'm not familiar with the conventions and etiquette.