### PR TITLE
add `no_std` compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,7 @@ An impl of `rand::Rng` based on a talk by Squirrel Eiserloh re: Math for Game Pr
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "0.8.5"
+rand = { version = "0.8.5", default-features = false, features = ["getrandom"] }
+
+[features]
+std = ["rand/std", "rand/std_rng"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ An impl of `rand::Rng` based on a talk by Squirrel Eiserloh re: Math for Game Pr
 rand = { version = "0.8.5", default-features = false, features = ["getrandom"] }
 
 [features]
+default = ["std"]
 std = ["rand/std", "rand/std_rng"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,9 @@ An impl of `rand::Rng` based on a talk by Squirrel Eiserloh re: Math for Game Pr
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = { version = "0.8.5", default-features = false, features = ["getrandom"] }
+rand = { version = "0.8.5", default-features = false }
 
 [features]
 default = ["std"]
+getrandom = ["rand/getrandom"]
 std = ["rand/std", "rand/std_rng"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 
+#[cfg(feature = "getrandom")]
 use rand::rngs::OsRng;
 #[cfg(feature = "std")]
 use rand::rngs::ThreadRng;
@@ -50,6 +51,7 @@ impl From<ThreadRng> for SquirrelRng {
     }
 }
 
+#[cfg(feature = "getrandom")]
 impl From<OsRng> for SquirrelRng {
     fn from(value: OsRng) -> Self {
         Self::seed_from(value)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
-pub use rand::{Rng, RngCore, SeedableRng};
+#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 
-use rand::rngs::{OsRng, ThreadRng};
+use rand::rngs::OsRng;
+#[cfg(feature = "std")]
+use rand::rngs::ThreadRng;
+pub use rand::{Rng, RngCore, SeedableRng};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct SquirrelRng {
@@ -9,6 +12,7 @@ pub struct SquirrelRng {
 }
 
 impl SquirrelRng {
+    #[cfg(feature = "std")]
     pub fn new() -> Self {
         Self {
             position: 0,
@@ -32,12 +36,14 @@ impl SquirrelRng {
     }
 }
 
+#[cfg(feature = "std")]
 impl Default for SquirrelRng {
     fn default() -> Self {
         SquirrelRng::new()
     }
 }
 
+#[cfg(feature = "std")]
 impl From<ThreadRng> for SquirrelRng {
     fn from(value: ThreadRng) -> Self {
         Self::seed_from(value)


### PR DESCRIPTION
this PR adds support for `no_std`. In order to do so it supplies two feature flags:
- `std`, for full-featured stdlib compatibility ("as it was before this PR")
- `getrandom`, for scenarios where you do have some kind of `OsRng` but no `std` (say, in an embedded RTOS, or maybe any kind of kernel?). I have not tested this scenario.